### PR TITLE
[SC]: Implement Pause/Unpause Mechanism for Emergency Control in Budg…

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,3 @@
 scarb 2.9.2
 snforge_std 0.36.0
-
 starknet-foundry 0.36.0

--- a/src/base/errors.cairo
+++ b/src/base/errors.cairo
@@ -29,3 +29,5 @@ pub const ONLY_ADMIN: felt252 = 'ONLY ADMIN';
 pub const ERROR_FUNDS_ALREADY_RELEASED: felt252 = 'Funds already released';
 pub const ERROR_MILESTONE_NOT_COMPLETED: felt252 = 'Milestone not completed';
 pub const ERROR_UNAUTHORIZED_REQUESTER: felt252 = 'Only project owner can request';
+pub const ERROR_CONTRACT_PAUSED: felt252 = 'Contract is paused';
+pub const ERROR_ALREADY_PAUSED: felt252 = 'Contract already paused';

--- a/src/budgetchain/Budget.cairo
+++ b/src/budgetchain/Budget.cairo
@@ -62,6 +62,7 @@ pub mod Budget {
         milestone_funds_released: LegacyMap<(u64, u64), bool>,
         project_owners: LegacyMap<u64, ContractAddress>,
         milestone_statuses: LegacyMap<(u64, u64), bool>,
+        is_paused: bool,
     }
 
 
@@ -170,7 +171,10 @@ pub mod Budget {
         //     amount: u128,
         //     category: felt252,
         //     description: felt252,
-        // ) -> Result<u64, felt252> {}
+        // ) -> Result<u64, felt252> {
+
+        //     // Ensure the contract is not paused
+        //     self.assert_not_paused();}
 
         fn get_transaction(self: @ContractState, id: u64) -> Result<Transaction, felt252> {
             assert(id > 0 && id <= self.transaction_count.read(), ERROR_INVALID_TRANSACTION_ID);
@@ -243,6 +247,9 @@ pub mod Budget {
             milestone_descriptions: Array<felt252>,
             milestone_amounts: Array<u256>,
         ) -> u64 {
+            // Ensure the contract is not paused
+            self.assert_not_paused();
+
             let caller = get_caller_address();
             assert(self.org_addresses.entry(org).read(), ERROR_UNAUTHORIZED);
             assert(caller == org, ERROR_CALLER_NOT_ORG);
@@ -456,6 +463,8 @@ pub mod Budget {
         fn release_funds(
             ref self: ContractState, org: ContractAddress, project_id: u64, request_id: u64,
         ) {
+            // Ensure the contract is not paused
+            self.assert_not_paused();
             // Verify caller is an authorized organization
             self.accesscontrol.assert_only_role(ORGANIZATION_ROLE);
 
@@ -584,12 +593,46 @@ pub mod Budget {
         fn get_milestone(self: @ContractState, project_id: u64, milestone_id: u64) -> Milestone {
             self.milestones.read((project_id, milestone_id))
         }
+        fn pause_contract(ref self: ContractState) {
+            // Ensure only the admin can pause the contract
+            let caller = get_caller_address();
+            assert(caller == self.admin.read(), ERROR_ONLY_ADMIN);
+            // check if already paused
+            assert(!self.is_paused.read(), ERROR_ALREADY_PAUSED);
+            // Set the paused state to true
+            self.is_paused.write(true);
+        }
+        fn unpause_contract(ref self: ContractState) {
+            // Ensure only the admin can unpause the contract
+            let caller = get_caller_address();
+            assert(caller == self.admin.read(), ERROR_ONLY_ADMIN);
+
+            // Set the paused state to false
+            self.is_paused.write(false);
+        }
+        fn is_paused(self: @ContractState) -> bool {
+            self.is_paused.read()
+        }
         // fn request_funds(
     //     ref self: ContractState,
     //     requester: ContractAddress,
     //     project_id: u64,
     //     milestone_id: u64,
     //     request_id: u64,
-    // ) -> u64 { }
+    // ) -> u64 {
+    // Ensure the contract is not paused
+    // self.assert_not_paused();
+
+        //  }
+    }
+
+    #[generate_trait]
+    pub impl Internal of InternalTrait {
+        // Internal view function
+        // - Takes `@self` as it only needs to read state
+        // - Can only be called by other functions within the contract
+        fn assert_not_paused(self: @ContractState) {
+            assert(!self.is_paused.read(), ERROR_CONTRACT_PAUSED);
+        }
     }
 }

--- a/src/interfaces/IBudget.cairo
+++ b/src/interfaces/IBudget.cairo
@@ -87,6 +87,7 @@ pub trait IBudget<TContractState> {
     fn check_owner(self: @TContractState, requester: ContractAddress, project_id: u64);
     fn set_fund_requests_counter(ref self: TContractState, value: u64) -> bool;
     fn get_fund_requests_counter(self: @TContractState) -> u64;
+
     fn pause_contract(ref self: TContractState);
     fn unpause_contract(ref self: TContractState);
     fn is_paused(self: @TContractState) -> bool;

--- a/src/interfaces/IBudget.cairo
+++ b/src/interfaces/IBudget.cairo
@@ -87,4 +87,7 @@ pub trait IBudget<TContractState> {
     fn check_owner(self: @TContractState, requester: ContractAddress, project_id: u64);
     fn set_fund_requests_counter(ref self: TContractState, value: u64) -> bool;
     fn get_fund_requests_counter(self: @TContractState) -> u64;
+    fn pause_contract(ref self: TContractState);
+    fn unpause_contract(ref self: TContractState);
+    fn is_paused(self: @TContractState) -> bool;
 }

--- a/tests/test_budgetchain.cairo
+++ b/tests/test_budgetchain.cairo
@@ -770,3 +770,214 @@ fn test_get_project_remaining_budget_invalid_project() {
     // Try to get remaining budget for a non-existent project
     dispatcher.get_project_remaining_budget(999);
 }
+
+#[test]
+fn test_pause_contract() {
+    // Setup project with milestones
+    let (contract_address, admin_address, org_address, project_owner, project_id, total_budget) =
+        setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Create one milestone for the full budget
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let milestone_id = dispatcher
+        .create_milestone(org_address, project_id, 'Full Budget Milestone', total_budget);
+    stop_cheat_caller_address(admin_address);
+
+    // Mark milestone as complete
+    cheat_caller_address(contract_address, project_owner, CheatSpan::Indefinite);
+    dispatcher.set_milestone_complete(project_id, milestone_id);
+    stop_cheat_caller_address(project_owner);
+
+    // pause contract
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // assert contract was paused
+    let is_paused = dispatcher.is_paused();
+    assert(is_paused == true, 'Contract should be paused');
+}
+
+
+#[test]
+#[should_panic(expected: 'ONLY ADMIN')]
+fn test_pause_contract_should_panic_if_non_admin() {
+    // Setup project with milestones
+    let (contract_address, admin_address, org_address, project_owner, project_id, total_budget) =
+        setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let another_user = contract_address_const::<'ProjectOwner'>();
+
+    // Create one milestone for the full budget
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let milestone_id = dispatcher
+        .create_milestone(org_address, project_id, 'Full Budget Milestone', total_budget);
+    stop_cheat_caller_address(admin_address);
+
+    // Mark milestone as complete
+    cheat_caller_address(contract_address, project_owner, CheatSpan::Indefinite);
+    dispatcher.set_milestone_complete(project_id, milestone_id);
+    stop_cheat_caller_address(project_owner);
+
+    // pause contract
+    cheat_caller_address(contract_address, another_user, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // assert contract was paused
+    let is_paused = dispatcher.is_paused();
+    assert(is_paused == true, 'Contract should be paused');
+}
+
+#[test]
+#[should_panic(expected: 'Contract already paused')]
+fn test_pause_contract_should_panic_if_already_paused() {
+    // Setup project with milestones
+    let (contract_address, admin_address, org_address, project_owner, project_id, total_budget) =
+        setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Create one milestone for the full budget
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let milestone_id = dispatcher
+        .create_milestone(org_address, project_id, 'Full Budget Milestone', total_budget);
+    stop_cheat_caller_address(admin_address);
+
+    // Mark milestone as complete
+    cheat_caller_address(contract_address, project_owner, CheatSpan::Indefinite);
+    dispatcher.set_milestone_complete(project_id, milestone_id);
+    stop_cheat_caller_address(project_owner);
+
+    // pause contract
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // assert contract was paused
+    let is_paused = dispatcher.is_paused();
+    assert(is_paused == true, 'Contract should be paused');
+
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+}
+
+
+#[test]
+fn test_unpause_contract() {
+    // Setup project with milestones
+    let (contract_address, admin_address, org_address, project_owner, project_id, total_budget) =
+        setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Create one milestone for the full budget
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let milestone_id = dispatcher
+        .create_milestone(org_address, project_id, 'Full Budget Milestone', total_budget);
+    stop_cheat_caller_address(admin_address);
+
+    // Mark milestone as complete
+    cheat_caller_address(contract_address, project_owner, CheatSpan::Indefinite);
+    dispatcher.set_milestone_complete(project_id, milestone_id);
+    stop_cheat_caller_address(project_owner);
+
+    // pause contract
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // assert contract was paused
+    let is_paused = dispatcher.is_paused();
+    assert(is_paused == true, 'Contract should be paused');
+
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.unpause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // assert contract was unpaused
+    let is_paused = dispatcher.is_paused();
+    assert(is_paused == false, 'Contract should not be paused');
+}
+
+
+#[test]
+#[should_panic(expected: 'ONLY ADMIN')]
+fn test_unpause_contract_should_panic_if_not_admin() {
+    // Setup project with milestones
+    let (contract_address, admin_address, org_address, project_owner, project_id, total_budget) =
+        setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let another_user = contract_address_const::<'ProjectOwner'>();
+
+    // Create one milestone for the full budget
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let milestone_id = dispatcher
+        .create_milestone(org_address, project_id, 'Full Budget Milestone', total_budget);
+    stop_cheat_caller_address(admin_address);
+
+    // Mark milestone as complete
+    cheat_caller_address(contract_address, project_owner, CheatSpan::Indefinite);
+    dispatcher.set_milestone_complete(project_id, milestone_id);
+    stop_cheat_caller_address(project_owner);
+
+    // pause contract
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // assert contract was paused
+    let is_paused = dispatcher.is_paused();
+    assert(is_paused == true, 'Contract should be paused');
+
+    cheat_caller_address(contract_address, another_user, CheatSpan::Indefinite);
+    dispatcher.unpause_contract();
+    stop_cheat_caller_address(admin_address);
+}
+
+
+#[test]
+#[should_panic(expected: 'Contract is paused')]
+fn test_functions_should_panic_when_contract_is_done() {
+    // Setup project with no budget
+    let (contract_address, admin_address) = setup();
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Create organization
+    let org_name = 'Test Org';
+    let org_address = contract_address_const::<'Organization'>();
+    let org_mission = 'Testing Budget Chain';
+
+    // Create project owner
+    let project_owner = contract_address_const::<'ProjectOwner'>();
+
+    // Set admin as caller to create organization
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let _org_id = dispatcher.create_organization(org_name, org_address, org_mission);
+    stop_cheat_caller_address(admin_address);
+
+    // Create project with zero budget
+    let total_budget: u256 = 0;
+
+    // Set milestone descriptions and amounts
+    let mut milestone_descriptions = array!['Empty Milestone'];
+    let mut milestone_amounts = array![total_budget];
+
+    // pause contract
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // Set org_address as caller to create project
+    cheat_caller_address(contract_address, org_address, CheatSpan::Indefinite);
+    dispatcher
+        .allocate_project_budget(
+            org_address, project_owner, total_budget, milestone_descriptions, milestone_amounts,
+        );
+    stop_cheat_caller_address(org_address);
+}


### PR DESCRIPTION
# Add Contract Pause Functionality

## Summary
This PR adds pause/unpause functionality to the BudgetChain contract to allow administrators to temporarily halt operations in case of emergencies or maintenance.

## Changes
- Added `is_paused` state variable to track the contract's operational status
- Implemented `pause_contract()` and `unpause_contract()` functions with admin-only access
- Added `is_paused()` view function for external status checking
- Created `assert_not_paused()` internal helper function for validation
- Added pause checks to critical contract functions
- Added new error constants for pause-related operations

## Security Considerations
- Only the admin address can pause or unpause the contract
- Prevention of double-pausing with appropriate error messages
- Critical functions like fund management and project creation now verify the contract isn't paused

## Testing
All tests pass on the updated implementation. The pause functionality effectively halts operations when activated.
Fixes #50