### PR TITLE
feat: add return funds funcntionality

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,3 @@
-scarb 2.9.2
+scarb 2.11.3
 snforge_std 0.36.0
-
 starknet-foundry 0.36.0

--- a/src/budgetchain/Budget.cairo
+++ b/src/budgetchain/Budget.cairo
@@ -217,13 +217,13 @@ pub mod Budget {
                 let fund_request = self.fund_requests.read((project_id, current_index));
                 fund_requests_to_return.append(fund_request);
                 current_index += 1;
-            };
+            }
 
             fund_requests_to_return
         }
 
         fn return_funds(
-            ref self: ContractState, project_owner: ContractAddress, project_id: u64, amount: u256
+            ref self: ContractState, project_owner: ContractAddress, project_id: u64, amount: u256,
         ) {
             assert(project_id != 0, 'Invalid project ID');
             assert(amount > 0, 'Amount cannot be zero');
@@ -314,7 +314,7 @@ pub mod Budget {
             while i < milestone_count {
                 sum += *milestone_amounts.at(i.into());
                 i += 1;
-            };
+            }
             assert(sum == total_budget, ERROR_BUDGET_MISMATCH);
 
             let project_id = self.project_count.read();
@@ -342,7 +342,7 @@ pub mod Budget {
                         },
                     );
                 j += 1;
-            };
+            }
 
             self.project_count.write(project_id + 1);
             self.org_milestones.write(org, milestone_count.try_into().unwrap());

--- a/src/budgetchain/Budget.cairo
+++ b/src/budgetchain/Budget.cairo
@@ -217,7 +217,7 @@ pub mod Budget {
                 let fund_request = self.fund_requests.read((project_id, current_index));
                 fund_requests_to_return.append(fund_request);
                 current_index += 1;
-            }
+            };
 
             fund_requests_to_return
         }
@@ -314,7 +314,7 @@ pub mod Budget {
             while i < milestone_count {
                 sum += *milestone_amounts.at(i.into());
                 i += 1;
-            }
+            };
             assert(sum == total_budget, ERROR_BUDGET_MISMATCH);
 
             let project_id = self.project_count.read();
@@ -342,7 +342,7 @@ pub mod Budget {
                         },
                     );
                 j += 1;
-            }
+            };
 
             self.project_count.write(project_id + 1);
             self.org_milestones.write(org, milestone_count.try_into().unwrap());

--- a/src/interfaces/IBudget.cairo
+++ b/src/interfaces/IBudget.cairo
@@ -84,6 +84,9 @@ pub trait IBudget<TContractState> {
     fn check_milestone(
         self: @TContractState, requester: ContractAddress, project_id: u64, milestone_id: u64,
     );
+    fn return_funds(
+        ref self: TContractState, project_owner: ContractAddress, project_id: u64, amount: u256,
+    );
     fn check_owner(self: @TContractState, requester: ContractAddress, project_id: u64);
     fn set_fund_requests_counter(ref self: TContractState, value: u64) -> bool;
     fn get_fund_requests_counter(self: @TContractState) -> u64;

--- a/tests/test_budgetchain.cairo
+++ b/tests/test_budgetchain.cairo
@@ -1,4 +1,4 @@
-use budgetchain_contracts::base::types::{Transaction};
+use budgetchain_contracts::base::types::Transaction;
 use budgetchain_contracts::budgetchain::Budget;
 use budgetchain_contracts::interfaces::IBudget::{IBudgetDispatcher, IBudgetDispatcherTrait};
 use snforge_std::{
@@ -549,7 +549,7 @@ fn test__return_funds() {
 
 #[test]
 #[should_panic(expected: 'Amount cannot be zero')]
-fn test_zero_amount(){
+fn test_zero_amount() {
     let (contract_address, admin_address) = setup();
 
     let org_address = contract_address_const::<'Organization'>();
@@ -557,14 +557,13 @@ fn test_zero_amount(){
 
     let dispatcher = IBudgetDispatcher { contract_address };
 
-
-        start_cheat_caller_address(contract_address, proj_owner);
+    start_cheat_caller_address(contract_address, proj_owner);
     dispatcher.return_funds(proj_owner, 19, 0);
 }
 
 #[test]
 #[should_panic(expected: 'Amount cannot be zero')]
-fn test_refund_transaction_count(){
+fn test_refund_transaction_count() {
     let (contract_address, admin_address) = setup();
 
     let org_address = contract_address_const::<'Organization'>();
@@ -573,13 +572,10 @@ fn test_refund_transaction_count(){
     let dispatcher = IBudgetDispatcher { contract_address };
     let count = dispatcher.get_transaction_count();
     assert(count == 0, 'incorrect deployment');
-    
-  
-        start_cheat_caller_address(contract_address, proj_owner);
+
+    start_cheat_caller_address(contract_address, proj_owner);
     dispatcher.return_funds(proj_owner, 17, 0);
     assert(count == 1, 'An error occured');
-
-
 }
 
 #[test]

--- a/tests/test_budgetchain.cairo
+++ b/tests/test_budgetchain.cairo
@@ -76,6 +76,28 @@ fn test_initial_data() {
 }
 
 #[test]
+#[should_panic(expected: 'Caller not authorized')]
+fn test_not_owner_calling_return_fund() {
+    let (contract_address, admin_address) = setup();
+    let org_address = contract_address_const::<'org_addr'>();
+    let project_owner = contract_address_const::<'owner'>();
+    let not_owner = contract_address_const::<'not_owner'>();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    start_cheat_caller_address(dispatcher.contract_address, not_owner);
+    // Set org_address as caller to create project
+    let project_id = dispatcher
+        .allocate_project_budget(
+            org_address, project_owner, 400, array!['Milestone1', 'Milestone2'], array![28, 74],
+        );
+    stop_cheat_caller_address(org_address);
+    // Ensure dispatcher methods exist
+    dispatcher.return_funds(project_owner, project_id, 400);
+}
+
+
+#[test]
 fn test_create_organization() {
     let (contract_address, admin_address) = setup();
 
@@ -511,6 +533,53 @@ fn test__milestone_completed() {
     let dispatcher = IBudgetDispatcher { contract_address };
 
     dispatcher.check_milestone(caller, 20, 30);
+}
+
+#[test]
+#[should_panic(expected: 'Invalid project ID')]
+fn test__return_funds() {
+    let (contract_address, _admin_address) = setup();
+    let owner = contract_address_const::<'owner'>();
+
+    start_cheat_caller_address(contract_address, owner);
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    dispatcher.return_funds(owner, 0, 30);
+}
+
+#[test]
+#[should_panic(expected: 'Amount cannot be zero')]
+fn test_zero_amount(){
+    let (contract_address, admin_address) = setup();
+
+    let org_address = contract_address_const::<'Organization'>();
+    let proj_owner = contract_address_const::<'owner'>();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+
+        start_cheat_caller_address(contract_address, proj_owner);
+    dispatcher.return_funds(proj_owner, 19, 0);
+}
+
+#[test]
+#[should_panic(expected: 'Amount cannot be zero')]
+fn test_refund_transaction_count(){
+    let (contract_address, admin_address) = setup();
+
+    let org_address = contract_address_const::<'Organization'>();
+    let proj_owner = contract_address_const::<'owner'>();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let count = dispatcher.get_transaction_count();
+    assert(count == 0, 'incorrect deployment');
+    
+  
+        start_cheat_caller_address(contract_address, proj_owner);
+    dispatcher.return_funds(proj_owner, 17, 0);
+    assert(count == 1, 'An error occured');
+
+
 }
 
 #[test]


### PR DESCRIPTION
Closes #14 

Adds the `return_funds` function, enabling project owners to return unused funds.

This functionality ensures that:

- Only the designated `project_owner` can initiate fund returns.
- Each successful return is recorded as a transaction.
- A `FundsReturned` event, containing the `project_id` and returned `amount`, is emitted.