### PR TITLE
Feat: implemented get_project_transactions function

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,2 @@
 scarb 2.9.2
-snforge_std 0.36.0
 starknet-foundry 0.36.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,3 @@
 scarb 2.9.2
 snforge_std 0.36.0
-
 starknet-foundry 0.36.0

--- a/src/base/errors.cairo
+++ b/src/base/errors.cairo
@@ -29,3 +29,5 @@ pub const ONLY_ADMIN: felt252 = 'ONLY ADMIN';
 pub const ERROR_FUNDS_ALREADY_RELEASED: felt252 = 'Funds already released';
 pub const ERROR_MILESTONE_NOT_COMPLETED: felt252 = 'Milestone not completed';
 pub const ERROR_UNAUTHORIZED_REQUESTER: felt252 = 'Only project owner can request';
+pub const ERROR_CONTRACT_PAUSED: felt252 = 'Contract is paused';
+pub const ERROR_ALREADY_PAUSED: felt252 = 'Contract already paused';

--- a/src/interfaces/IBudget.cairo
+++ b/src/interfaces/IBudget.cairo
@@ -6,14 +6,14 @@ use starknet::ContractAddress;
 #[starknet::interface]
 pub trait IBudget<TContractState> {
     // Transaction Management
-    // fn create_transaction(
-    //     ref self: TContractState,
-    //     project_id: u64,
-    //     recipient: ContractAddress,
-    //     amount: u128,
-    //     category: felt252,
-    //     description: felt252,
-    // ) -> Result<u64, felt252>;
+    fn create_transaction(
+        ref self: TContractState,
+        project_id: u64,
+        recipient: ContractAddress,
+        amount: u128,
+        category: felt252,
+        description: felt252,
+    ) -> Result<u64, felt252>;
     fn get_transaction(self: @TContractState, id: u64) -> Result<Transaction, felt252>;
     // fn get_transaction_history(
     //     self: @TContractState, page: u64, page_size: u64,
@@ -88,6 +88,9 @@ pub trait IBudget<TContractState> {
     fn check_owner(self: @TContractState, requester: ContractAddress, project_id: u64);
     fn set_fund_requests_counter(ref self: TContractState, value: u64) -> bool;
     fn get_fund_requests_counter(self: @TContractState) -> u64;
+    fn get_project_transactions(
+        self: @TContractState, project_id: u64, page: u64, page_size: u64,
+    ) -> Result<(Array<Transaction>, u64), felt252>;
 
     fn pause_contract(ref self: TContractState);
     fn unpause_contract(ref self: TContractState);

--- a/src/interfaces/IBudget.cairo
+++ b/src/interfaces/IBudget.cairo
@@ -88,4 +88,8 @@ pub trait IBudget<TContractState> {
     fn check_owner(self: @TContractState, requester: ContractAddress, project_id: u64);
     fn set_fund_requests_counter(ref self: TContractState, value: u64) -> bool;
     fn get_fund_requests_counter(self: @TContractState) -> u64;
+
+    fn pause_contract(ref self: TContractState);
+    fn unpause_contract(ref self: TContractState);
+    fn is_paused(self: @TContractState) -> bool;
 }

--- a/tests/test_budgetchain.cairo
+++ b/tests/test_budgetchain.cairo
@@ -772,6 +772,218 @@ fn test_get_project_remaining_budget_invalid_project() {
 }
 
 #[test]
+fn test_pause_contract() {
+    // Setup project with milestones
+    let (contract_address, admin_address, org_address, project_owner, project_id, total_budget) =
+        setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Create one milestone for the full budget
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let milestone_id = dispatcher
+        .create_milestone(org_address, project_id, 'Full Budget Milestone', total_budget);
+    stop_cheat_caller_address(admin_address);
+
+    // Mark milestone as complete
+    cheat_caller_address(contract_address, project_owner, CheatSpan::Indefinite);
+    dispatcher.set_milestone_complete(project_id, milestone_id);
+    stop_cheat_caller_address(project_owner);
+
+    // pause contract
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // assert contract was paused
+    let is_paused = dispatcher.is_paused();
+    assert(is_paused == true, 'Contract should be paused');
+}
+
+
+#[test]
+#[should_panic(expected: 'ONLY ADMIN')]
+fn test_pause_contract_should_panic_if_non_admin() {
+    // Setup project with milestones
+    let (contract_address, admin_address, org_address, project_owner, project_id, total_budget) =
+        setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let another_user = contract_address_const::<'ProjectOwner'>();
+
+    // Create one milestone for the full budget
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let milestone_id = dispatcher
+        .create_milestone(org_address, project_id, 'Full Budget Milestone', total_budget);
+    stop_cheat_caller_address(admin_address);
+
+    // Mark milestone as complete
+    cheat_caller_address(contract_address, project_owner, CheatSpan::Indefinite);
+    dispatcher.set_milestone_complete(project_id, milestone_id);
+    stop_cheat_caller_address(project_owner);
+
+    // pause contract
+    cheat_caller_address(contract_address, another_user, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // assert contract was paused
+    let is_paused = dispatcher.is_paused();
+    assert(is_paused == true, 'Contract should be paused');
+}
+
+#[test]
+#[should_panic(expected: 'Contract already paused')]
+fn test_pause_contract_should_panic_if_already_paused() {
+    // Setup project with milestones
+    let (contract_address, admin_address, org_address, project_owner, project_id, total_budget) =
+        setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Create one milestone for the full budget
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let milestone_id = dispatcher
+        .create_milestone(org_address, project_id, 'Full Budget Milestone', total_budget);
+    stop_cheat_caller_address(admin_address);
+
+    // Mark milestone as complete
+    cheat_caller_address(contract_address, project_owner, CheatSpan::Indefinite);
+    dispatcher.set_milestone_complete(project_id, milestone_id);
+    stop_cheat_caller_address(project_owner);
+
+    // pause contract
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // assert contract was paused
+    let is_paused = dispatcher.is_paused();
+    assert(is_paused == true, 'Contract should be paused');
+
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+}
+
+
+#[test]
+fn test_unpause_contract() {
+    // Setup project with milestones
+    let (contract_address, admin_address, org_address, project_owner, project_id, total_budget) =
+        setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Create one milestone for the full budget
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let milestone_id = dispatcher
+        .create_milestone(org_address, project_id, 'Full Budget Milestone', total_budget);
+    stop_cheat_caller_address(admin_address);
+
+    // Mark milestone as complete
+    cheat_caller_address(contract_address, project_owner, CheatSpan::Indefinite);
+    dispatcher.set_milestone_complete(project_id, milestone_id);
+    stop_cheat_caller_address(project_owner);
+
+    // pause contract
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // assert contract was paused
+    let is_paused = dispatcher.is_paused();
+    assert(is_paused == true, 'Contract should be paused');
+
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.unpause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // assert contract was unpaused
+    let is_paused = dispatcher.is_paused();
+    assert(is_paused == false, 'Contract should not be paused');
+}
+
+
+#[test]
+#[should_panic(expected: 'ONLY ADMIN')]
+fn test_unpause_contract_should_panic_if_not_admin() {
+    // Setup project with milestones
+    let (contract_address, admin_address, org_address, project_owner, project_id, total_budget) =
+        setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let another_user = contract_address_const::<'ProjectOwner'>();
+
+    // Create one milestone for the full budget
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let milestone_id = dispatcher
+        .create_milestone(org_address, project_id, 'Full Budget Milestone', total_budget);
+    stop_cheat_caller_address(admin_address);
+
+    // Mark milestone as complete
+    cheat_caller_address(contract_address, project_owner, CheatSpan::Indefinite);
+    dispatcher.set_milestone_complete(project_id, milestone_id);
+    stop_cheat_caller_address(project_owner);
+
+    // pause contract
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // assert contract was paused
+    let is_paused = dispatcher.is_paused();
+    assert(is_paused == true, 'Contract should be paused');
+
+    cheat_caller_address(contract_address, another_user, CheatSpan::Indefinite);
+    dispatcher.unpause_contract();
+    stop_cheat_caller_address(admin_address);
+}
+
+
+#[test]
+#[should_panic(expected: 'Contract is paused')]
+fn test_functions_should_panic_when_contract_is_done() {
+    // Setup project with no budget
+    let (contract_address, admin_address) = setup();
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Create organization
+    let org_name = 'Test Org';
+    let org_address = contract_address_const::<'Organization'>();
+    let org_mission = 'Testing Budget Chain';
+
+    // Create project owner
+    let project_owner = contract_address_const::<'ProjectOwner'>();
+
+    // Set admin as caller to create organization
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let _org_id = dispatcher.create_organization(org_name, org_address, org_mission);
+    stop_cheat_caller_address(admin_address);
+
+    // Create project with zero budget
+    let total_budget: u256 = 0;
+
+    // Set milestone descriptions and amounts
+    let mut milestone_descriptions = array!['Empty Milestone'];
+    let mut milestone_amounts = array![total_budget];
+
+    // pause contract
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.pause_contract();
+    stop_cheat_caller_address(admin_address);
+
+    // Set org_address as caller to create project
+    cheat_caller_address(contract_address, org_address, CheatSpan::Indefinite);
+    dispatcher
+        .allocate_project_budget(
+            org_address, project_owner, total_budget, milestone_descriptions, milestone_amounts,
+        );
+    stop_cheat_caller_address(org_address);
+}
+
+
+#[test]
 #[should_panic(expected: 'Invalid project ID')]
 fn test_get_project_budget_invalid_project() {
     let (contract_address, _) = setup();

--- a/tests/test_budgetchain.cairo
+++ b/tests/test_budgetchain.cairo
@@ -1213,3 +1213,165 @@ fn test_get_project_budget_initial() {
     let remaining_budget = budget_dispatcher.get_project_budget(project_id);
     assert(remaining_budget == total_budget, 'Initial budget incorrect');
 }
+
+#[test]
+fn test_get_project_transactions_basic() {
+    let (contract_address, _) = setup();
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let recipient = contract_address_const::<'recipient'>();
+    let project_id: u64 = 42;
+    let category: felt252 = project_id.into();
+    let description = 'Test transaction';
+    // Create 5 transactions for the project
+    let mut i = 0_u64;
+    while i < 5_u64 {
+        dispatcher.create_transaction(project_id, recipient, 1000, category, description).unwrap();
+        i += 1_u64;
+    };
+    // Retrieve all transactions (page 1, size 5)
+    let (txs, total) = dispatcher.get_project_transactions(project_id, 1, 5).unwrap();
+
+    assert(total == 5_u64, 'Total should be 5');
+    assert(txs.len() == 5_u32, 'Should return 5 transactions');
+}
+
+#[test]
+fn test_get_project_transactions_pagination_and_integrity() {
+    let (contract_address, _) = setup();
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let recipient = contract_address_const::<'recipient'>();
+    let project_id: u64 = 42;
+    let category: felt252 = project_id.into();
+    let description = 'Test transaction';
+    // Create 25 transactions for the project
+    let mut i = 0_u64;
+    while i < 25_u64 {
+        let amount: u128 = (1000 + i).into();
+        dispatcher
+            .create_transaction(project_id, recipient, amount, category, description)
+            .unwrap();
+        i += 1_u64;
+    };
+
+    // Retrieve first page (page 1, size 10)
+    let (txs, total) = dispatcher.get_project_transactions(project_id, 1, 10).unwrap();
+    assert(total == 25_u64, 'Total should be 25');
+    assert(txs.len() == 10_u32, 'Should return 10 transactions');
+    // Check data integrity and order
+    let mut j = 0_u32;
+    while j < 10_u32 {
+        let tx = txs.get(j).unwrap();
+        let expected_id: u64 = j.into();
+        let expected_amount: u128 = (1000 + j).into();
+
+        assert(tx.id == expected_id, 'ID mismatch');
+        assert(tx.amount == expected_amount, 'Amount mismatch');
+        assert(tx.category == category, 'Category mismatch');
+        assert(tx.description == description, 'Description mismatch');
+        j += 1_u32;
+    };
+
+    // Retrieve last page (page 3, size 10)
+    let (txs_last, _) = dispatcher.get_project_transactions(project_id, 3, 10).unwrap();
+    assert(txs_last.len() == 5_u32, 'Page should have 5 transactions');
+    // Retrieve out-of-range page (page 4, size 10)
+    let (txs_empty, _) = dispatcher.get_project_transactions(project_id, 4, 10).unwrap();
+    assert(txs_empty.len() == 0_u32, 'Out-of-range, should be empty');
+}
+
+#[test]
+#[should_panic]
+fn test_get_project_transactions_no_transactions() {
+    let (contract_address, _) = setup();
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let project_id: u64 = 9999;
+    dispatcher.get_project_transactions(project_id, 1, 10).unwrap();
+}
+
+#[test]
+#[should_panic]
+fn test_get_project_transactions_invalid_page() {
+    let (contract_address, _) = setup();
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let project_id: u64 = 1;
+    dispatcher.get_project_transactions(project_id, 0, 10).unwrap();
+}
+
+#[test]
+#[should_panic]
+fn test_get_project_transactions_invalid_page_size_zero() {
+    let (contract_address, _) = setup();
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let project_id: u64 = 1;
+    dispatcher.get_project_transactions(project_id, 1, 0).unwrap();
+}
+
+#[test]
+#[should_panic]
+fn test_get_project_transactions_invalid_page_size_too_large() {
+    let (contract_address, _) = setup();
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let project_id: u64 = 1;
+    dispatcher.get_project_transactions(project_id, 1, 101).unwrap();
+}
+
+#[test]
+fn test_get_project_transactions_single_transaction() {
+    let (contract_address, _) = setup();
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let recipient = contract_address_const::<'recipient'>();
+    let project_id: u64 = 7;
+    let category: felt252 = project_id.into();
+    let description = 'Single transaction';
+    dispatcher.create_transaction(project_id, recipient, 1234, category, description).unwrap();
+    let (txs, total) = dispatcher.get_project_transactions(project_id, 1, 10).unwrap();
+    assert(total == 1_u64, 'Total should be 1');
+    assert(txs.len() == 1_u32, 'Should return 1 transaction');
+    let tx = txs.get(0).unwrap();
+    assert(tx.amount == 1234, 'Amount mismatch');
+    assert(tx.description == description, 'Description mismatch');
+}
+
+#[test]
+fn test_get_project_transactions_multiple_projects_isolation() {
+    let (contract_address, _) = setup();
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let recipient = contract_address_const::<'recipient'>();
+    let project_id1: u64 = 100;
+    let project_id2: u64 = 200;
+    let category1: felt252 = project_id1.into();
+    let category2: felt252 = project_id2.into();
+    dispatcher.create_transaction(project_id1, recipient, 1, category1, 'P1-T1').unwrap();
+    dispatcher.create_transaction(project_id2, recipient, 2, category2, 'P2-T1').unwrap();
+    dispatcher.create_transaction(project_id1, recipient, 3, category1, 'P1-T2').unwrap();
+    let (txs1, total1) = dispatcher.get_project_transactions(project_id1, 1, 10).unwrap();
+    let (txs2, total2) = dispatcher.get_project_transactions(project_id2, 1, 10).unwrap();
+    assert!(total1 == 2_u64, "Project 1 should have 2 transactions");
+    assert!(total2 == 1_u64, "Project 2 should have 1 transaction");
+    assert!(txs1.len() == 2_u32, "Project 1 should return 2 transactions");
+    assert!(txs2.len() == 1_u32, "Project 2 should return 1 transaction");
+    assert(txs1.get(0).unwrap().description == 'P1-T1', 'Project 1, Tx 1 desc mismatch');
+    assert(txs1.get(1).unwrap().description == 'P1-T2', 'Project 1, Tx 2 desc mismatch');
+    assert(txs2.get(0).unwrap().description == 'P2-T1', 'Project 2, Tx 1 desc mismatch');
+}
+
+#[test]
+fn test_project_transaction_count_and_storage() {
+    let (contract_address, _) = setup();
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let recipient = contract_address_const::<'recipient'>();
+    let project_id: u64 = 55;
+    let category: felt252 = project_id.into();
+    let description = 'Count test';
+    // Add 3 transactions
+    dispatcher.create_transaction(project_id, recipient, 1, category, description).unwrap();
+    dispatcher.create_transaction(project_id, recipient, 2, category, description).unwrap();
+    dispatcher.create_transaction(project_id, recipient, 3, category, description).unwrap();
+    let (txs, total) = dispatcher.get_project_transactions(project_id, 1, 10).unwrap();
+    assert(total == 3_u64, 'Total should be 3');
+    assert(txs.len() == 3_u32, 'Should return 3 transactions');
+    // Check order and IDs
+    assert(txs.get(0).unwrap().id == 0_u64, 'First tx id should be 0');
+    assert(txs.get(1).unwrap().id == 1_u64, 'Second tx id should be 1');
+    assert(txs.get(2).unwrap().id == 2_u64, 'Third tx id should be 2');
+}


### PR DESCRIPTION
closes #46

- Added a double map storage pattern to track transaction IDs per project.
- Implemented get_project_transactions with pagination (page, page_size) and robust input validation.
- Updated create_transaction to maintain the project-to-transaction mapping.
- Added comprehensive unit tests covering:
- Pagination and edge cases (no transactions, single transaction, invalid parameters)
- Data integrity and correct ordering
- Multiple project isolation
- Added NatSpec documentation to both the interface and contract implementation.