### PR TITLE
feat: add project termination feature

### DIFF
--- a/src/base/errors.cairo
+++ b/src/base/errors.cairo
@@ -33,3 +33,5 @@ pub const ERROR_CONTRACT_PAUSED: felt252 = 'Contract is paused';
 pub const ERROR_ALREADY_PAUSED: felt252 = 'Contract already paused';
 pub const ERROR_INVALID_MILESTONE_DESCRIPTION: felt252 = 'Invalid milestone description';
 pub const ERROR_INVALID_BUDGET: felt252 = 'Invalid budget';
+pub const ERROR_PROJECT_TERMINATED: felt252 = 'Project is terminated';
+pub const ERROR_PROJECT_ALREADY_TERMINATED: felt252 = 'Project already terminated';

--- a/src/interfaces/IBudget.cairo
+++ b/src/interfaces/IBudget.cairo
@@ -99,4 +99,6 @@ pub trait IBudget<TContractState> {
     fn pause_contract(ref self: TContractState);
     fn unpause_contract(ref self: TContractState);
     fn is_paused(self: @TContractState) -> bool;
+    fn terminate_project(ref self: TContractState, project_id: u64);
+    fn is_project_active(self: @TContractState, project_id: u64) -> bool;
 }


### PR DESCRIPTION

### Description 

Implemented project termination functionality that allows admins to mark projects as inactive, preventing further operations on completed or invalid projects.

####  Changes
- Added `project_status` mapping to track active/terminated state
-  Created `terminate_project function` (admin-only)
- Added `is_project_active`  as an internal helper function
- Implemented protective checks in fund operations
- Emitted ProjectTerminated event when projects are terminated

#### Tests
Added tests for:

- Default active status for new projects
- Admin-only termination permissions
- Preventing operations on terminated projects
- Event emission on termination
Error handling for invalid cases

Closes #64 
@anonfedora 
