### PR TITLE
feat: add project terminate feature

### DIFF
--- a/src/base/errors.cairo
+++ b/src/base/errors.cairo
@@ -33,3 +33,5 @@ pub const ERROR_CONTRACT_PAUSED: felt252 = 'Contract is paused';
 pub const ERROR_ALREADY_PAUSED: felt252 = 'Contract already paused';
 pub const ERROR_INVALID_MILESTONE_DESCRIPTION: felt252 = 'Invalid milestone description';
 pub const ERROR_INVALID_BUDGET: felt252 = 'Invalid budget';
+pub const ERROR_PROJECT_ALREADY_TERMINATED: felt252 = 'Project already terminated';
+pub const ERROR_PROJECT_TERMINATED: felt252 = 'Project is terminated';

--- a/src/budgetchain/Budget.cairo
+++ b/src/budgetchain/Budget.cairo
@@ -200,7 +200,7 @@ pub mod Budget {
 
             // Ensure project is active
             self._assert_project_active(project_id);
-            
+
             // Generate new transaction ID
             let transaction_id = self.transaction_count.read();
             let sender = get_caller_address();
@@ -908,7 +908,7 @@ pub mod Budget {
             let caller = get_caller_address();
             assert(caller == self.admin.read(), ERROR_ONLY_ADMIN);
 
-             let mut project = self.projects.read(project_id);
+            let mut project = self.projects.read(project_id);
             assert(project.id == project_id, ERROR_INVALID_PROJECT_ID);
 
             // Check if project is already terminated
@@ -936,10 +936,9 @@ pub mod Budget {
         }
 
         fn _assert_project_active(self: @ContractState, project_id: u64) {
-            // Check if the project is active 
+            // Check if the project is active
             let project_status = self.project_status.read(project_id);
             assert(project_status == true, ERROR_PROJECT_TERMINATED);
-
-            }
+        }
     }
 }

--- a/src/interfaces/IBudget.cairo
+++ b/src/interfaces/IBudget.cairo
@@ -99,4 +99,6 @@ pub trait IBudget<TContractState> {
     fn pause_contract(ref self: TContractState);
     fn unpause_contract(ref self: TContractState);
     fn is_paused(self: @TContractState) -> bool;
+    fn terminate_project(ref self: TContractState, project_id: u64);
+    fn assert_status(self: @TContractState, project_id: u64) -> bool;
 }

--- a/tests/test_budgetchain.cairo
+++ b/tests/test_budgetchain.cairo
@@ -190,7 +190,9 @@ fn test_create_two_organization() {
 
 #[test]
 fn test_create_milestone_successfully() {
-    let (contract_address, admin_address) = setup();
+    // let (contract_address, admin_address) = setup();
+    let (contract_address, admin_address, _, _, project_id, _) = setup_project_with_milestones();
+
 
     let dispatcher = IBudgetDispatcher { contract_address };
 
@@ -200,13 +202,15 @@ fn test_create_milestone_successfully() {
 
     cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
     let _org0_id = dispatcher.create_organization(name, org_address, mission);
-    dispatcher.create_milestone(org_address, 12, 'Feed Dogs in Lekki', 2);
+    dispatcher.create_milestone(org_address, project_id, 'Feed Dogs in Lekki', 2);
     stop_cheat_caller_address(admin_address);
 }
 
 #[test]
 fn test_create_multiple_milestone_successfully() {
-    let (contract_address, admin_address) = setup();
+    // let (contract_address, admin_address) = setup();
+    let (contract_address, admin_address, _, _, project_id, _) = setup_project_with_milestones();
+    let (_, _, _, _, project_id2, _) = setup_project_with_milestones();
 
     let dispatcher = IBudgetDispatcher { contract_address };
 
@@ -216,8 +220,8 @@ fn test_create_multiple_milestone_successfully() {
 
     cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
     let _org0_id = dispatcher.create_organization(name, org_address, mission);
-    dispatcher.create_milestone(org_address, 12, 'Feed Dogs in Lekki', 2);
-    dispatcher.create_milestone(org_address, 18, 'Feed Dogs in Kubwa', 20);
+    dispatcher.create_milestone(org_address, project_id, 'Feed Dogs in Lekki', 2);
+    dispatcher.create_milestone(org_address, project_id2, 'Feed Dogs in Kubwa', 20);
     stop_cheat_caller_address(admin_address);
 }
 
@@ -245,14 +249,13 @@ fn test_create_milestone_should_panic_if_not_organization() {
 
 #[test]
 fn test_create_milestone_data_saved() {
-    let (contract_address, admin_address) = setup();
+    let (contract_address, admin_address, _, _, project_id, _) = setup_project_with_milestones();
 
     let dispatcher = IBudgetDispatcher { contract_address };
 
     let name = 'John';
     let org_address = contract_address_const::<'Organization 1'>();
     let mission = 'Help the Poor';
-    let project_id = 12;
     let milestone_description = 'Feed Dogs in Lekki';
     let milestone_amount = 2;
 
@@ -265,7 +268,7 @@ fn test_create_milestone_data_saved() {
     let first_milestone = dispatcher.get_milestone(project_id, milestone_id);
     assert(milestone_id == 1, 'Milestone not saved');
     assert(first_milestone.organization == org_address, 'Org didnt create the miestone');
-    assert(first_milestone.project_id == 12, 'Org project id didnt match');
+    assert(first_milestone.project_id == project_id, 'Org project id didnt match');
     assert(
         first_milestone.milestone_description == milestone_description,
         'Org description id didnt match',
@@ -640,10 +643,11 @@ fn test_get_transaction_history_invalid_page_size_too_large() {
 #[should_panic(expected: 'Invalid page number')]
 fn test_get_transaction_history_page_beyond_range() {
     // Setup contract
-    let (contract_address, admin_address) = setup();
+     let (contract_address, admin_address, _, _, project_id, _) =
+        setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
     let recipient = contract_address_const::<'recipient'>();
-    let project_id: u64 = 1;
+    let project_id: u64 = project_id;
     let category: felt252 = 'TEST';
     let description = 'Out of range test';
 
@@ -663,10 +667,11 @@ fn test_get_transaction_history_page_beyond_range() {
 #[test]
 fn test_get_transaction_history_single_transaction() {
     // Setup contract
-    let (contract_address, admin_address) = setup();
+    let (contract_address, admin_address, _, _, project_id, _) =
+        setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
     let recipient = contract_address_const::<'recipient'>();
-    let project_id: u64 = 1;
+    let project_id: u64 = project_id;
     let category: felt252 = 'TEST';
     let description = 'Single transaction';
 
@@ -697,10 +702,11 @@ fn test_get_transaction_history_single_transaction() {
 #[test]
 fn test_get_transaction_history_max_page_size() {
     // Setup contract
-    let (contract_address, admin_address) = setup();
+    let (contract_address, admin_address, _, _, project_id, _) =
+        setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
     let recipient = contract_address_const::<'recipient'>();
-    let project_id: u64 = 1;
+    let project_id: u64 = project_id;
     let category: felt252 = 'TEST';
     let description = 'Max page size test';
 
@@ -1520,10 +1526,11 @@ fn test_get_project_budget_initial() {
 
 #[test]
 fn test_get_project_transactions_basic() {
-    let (contract_address, _) = setup();
+    let (contract_address, _admin_address, _org_address, _project_owner, project_id, _) =
+        setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
     let recipient = contract_address_const::<'recipient'>();
-    let project_id: u64 = 42;
+    let project_id: u64 = project_id;
     let category: felt252 = project_id.into();
     let description = 'Test transaction';
     // Create 5 transactions for the project
@@ -1541,10 +1548,11 @@ fn test_get_project_transactions_basic() {
 
 #[test]
 fn test_get_project_transactions_pagination_and_integrity() {
-    let (contract_address, _) = setup();
+    let (contract_address, _admin_address, _org_address, _project_owner, project_id, _) =
+        setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
     let recipient = contract_address_const::<'recipient'>();
-    let project_id: u64 = 42;
+    let project_id: u64 = project_id;
     let category: felt252 = project_id.into();
     let description = 'Test transaction';
     // Create 25 transactions for the project
@@ -1595,9 +1603,10 @@ fn test_get_project_transactions_no_transactions() {
 #[test]
 #[should_panic]
 fn test_get_project_transactions_invalid_page() {
-    let (contract_address, _) = setup();
+     let (contract_address, _admin_address, _org_address, _project_owner, project_id, _) =
+        setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
-    let project_id: u64 = 1;
+    let project_id: u64 = project_id;
     dispatcher.get_project_transactions(project_id, 0, 10).unwrap();
 }
 
@@ -1621,10 +1630,12 @@ fn test_get_project_transactions_invalid_page_size_too_large() {
 
 #[test]
 fn test_get_project_transactions_single_transaction() {
-    let (contract_address, _) = setup();
+    // let (contract_address, _) = setup();
+    let (contract_address, _, _, _, project_id, _) =
+        setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
     let recipient = contract_address_const::<'recipient'>();
-    let project_id: u64 = 7;
+    let project_id: u64 = project_id;
     let category: felt252 = project_id.into();
     let description = 'Single transaction';
     dispatcher.create_transaction(project_id, recipient, 1234, category, description).unwrap();
@@ -1637,34 +1648,54 @@ fn test_get_project_transactions_single_transaction() {
 }
 
 #[test]
-fn test_get_project_transactions_multiple_projects_isolation() {
-    let (contract_address, _) = setup();
-    let dispatcher = IBudgetDispatcher { contract_address };
+fn test_get_project_transactions_multiple_projects_isolationv2() {
+    // let (contract_address, _) = setup();
+    // Setup project with milestones
+    let (contract_address, _, org_address, project_owner, project_id, _) =
+        setup_project_with_milestones();
+        
+        let dispatcher = IBudgetDispatcher { contract_address };
+
+        // Create another project to get another project_id with project status set to true 
+    
+        // Create a second project in the same contract
+        cheat_caller_address(contract_address, org_address, CheatSpan::Indefinite);
+        let project_id2 = dispatcher.allocate_project_budget(
+            org_address,
+            project_owner,
+            2000, // different budget
+            array!['Second Project Milestone'],
+            array![2000]
+        );
+        stop_cheat_caller_address(org_address);
+
     let recipient = contract_address_const::<'recipient'>();
-    let project_id1: u64 = 100;
-    let project_id2: u64 = 200;
-    let category1: felt252 = project_id1.into();
+    let project_id1 = project_id;
+    let project_id2 = project_id2;
+   let category1: felt252 = project_id1.into();
     let category2: felt252 = project_id2.into();
     dispatcher.create_transaction(project_id1, recipient, 1, category1, 'P1-T1').unwrap();
-    dispatcher.create_transaction(project_id2, recipient, 2, category2, 'P2-T1').unwrap();
-    dispatcher.create_transaction(project_id1, recipient, 3, category1, 'P1-T2').unwrap();
+   dispatcher.create_transaction(project_id2, recipient, 2, category2, 'P2-T1').unwrap();
+     dispatcher.create_transaction(project_id1, recipient, 3, category1, 'P1-T2').unwrap();
     let (txs1, total1) = dispatcher.get_project_transactions(project_id1, 1, 10).unwrap();
     let (txs2, total2) = dispatcher.get_project_transactions(project_id2, 1, 10).unwrap();
-    assert!(total1 == 2_u64, "Project 1 should have 2 transactions");
-    assert!(total2 == 1_u64, "Project 2 should have 1 transaction");
+     assert!(total1 == 2_u64, "Project 1 should have 2 transactions");
+     assert!(total2 == 1_u64, "Project 2 should have 1 transaction");
     assert!(txs1.len() == 2_u32, "Project 1 should return 2 transactions");
-    assert!(txs2.len() == 1_u32, "Project 2 should return 1 transaction");
+     assert!(txs2.len() == 1_u32, "Project 2 should return 1 transaction");
     assert(txs1.get(0).unwrap().description == 'P1-T1', 'Project 1, Tx 1 desc mismatch');
     assert(txs1.get(1).unwrap().description == 'P1-T2', 'Project 1, Tx 2 desc mismatch');
-    assert(txs2.get(0).unwrap().description == 'P2-T1', 'Project 2, Tx 1 desc mismatch');
+     assert(txs2.get(0).unwrap().description == 'P2-T1', 'Project 2, Tx 1 desc mismatch');
 }
 
 #[test]
 fn test_project_transaction_count_and_storage() {
-    let (contract_address, _) = setup();
+    // Setup project
+    let (contract_address, _, _, _, project_id, _) =
+        setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
     let recipient = contract_address_const::<'recipient'>();
-    let project_id: u64 = 55;
+    let project_id: u64 = project_id;
     let category: felt252 = project_id.into();
     let description = 'Count test';
     // Add 3 transactions
@@ -1978,5 +2009,167 @@ fn test_allocate_project_event() {
         );
 
     stop_cheat_caller_address(org_address);
+}
+
+
+#[test]
+fn test_project_active_by_default() {
+    // Setup project with milestones
+    let (contract_address, _, _, _, project_id, _) = setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Verify project is active by default (not terminated)
+    let status_before = dispatcher.assert_status(project_id);
+    assert(status_before == true, 'Project to be active by default');
+}
+
+#[test]
+fn test_terminate_project() {
+    // Setup project with milestones
+    let (contract_address, admin_address, org_address, _, project_id, total_budget) =
+        setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Create one milestone for the full budget
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let milestone_id = dispatcher
+        .create_milestone(org_address, project_id, 'Full Budget Milestone', total_budget);
+    stop_cheat_caller_address(admin_address);
+
+    // Verify project is active initially
+    let status_before = dispatcher.assert_status(project_id);
+    assert(status_before == true, 'Project is not active');
+
+    // Terminate project as admin
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.terminate_project(project_id);
+    stop_cheat_caller_address(admin_address);
+
+    // Verify project is now terminated
+    let status_after = dispatcher.assert_status(project_id);
+    assert(status_after == false, 'Project should be terminated');
+}
+
+#[test]
+fn test_assert_status_nonexistent_project() {
+    let (contract_address, _) = setup();
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Check non-existent project
+    let status_before = dispatcher.assert_status(999);
+    assert(status_before == false, 'Non-project cant be terminated');
+}
+
+#[test]
+#[should_panic(expected: 'Project already terminated')]
+fn test_terminate_project_already_terminated() {
+    // Setup project with milestones
+    let (contract_address, admin_address, _, _, project_id, _) = setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Terminate project first time
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.terminate_project(project_id);
+    stop_cheat_caller_address(admin_address);
+
+    // Try to terminate again (should fail)
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.terminate_project(project_id);
+    stop_cheat_caller_address(admin_address);
+}
+
+#[test]
+fn test_terminate_project_event_emission() {
+    // Setup project with milestones
+    let (contract_address, admin_address, _, _, project_id, _) = setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+    let mut spy = spy_events();
+
+    // Terminate project as admin
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.terminate_project(project_id);
+    stop_cheat_caller_address(admin_address);
+
+    // Verify event emission
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    contract_address,
+                    Budget::Budget::Event::ProjectTerminated(
+                        Budget::Budget::ProjectTerminated { project_id },
+                    ),
+                ),
+            ],
+        );
+}
+
+
+#[test]
+#[should_panic(expected: 'Project is terminated')]
+fn test_create_fund_request_on_terminated_project() {
+    // Setup project with milestones
+    let (contract_address, admin_address, org_address, project_owner, project_id, total_budget) =
+        setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Create one milestone for the full budget
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let milestone_id = dispatcher
+        .create_milestone(org_address, project_id, 'Full Budget Milestone', total_budget);
+    stop_cheat_caller_address(admin_address);
+
+     // Mark milestone as complete
+    cheat_caller_address(contract_address, project_owner, CheatSpan::Indefinite);
+    dispatcher.set_milestone_complete(project_id, milestone_id);
+    stop_cheat_caller_address(project_owner);
+
+    // Verify project is active initially
+    let status_before = dispatcher.assert_status(project_id);
+    assert(status_before == true, 'Project is not active');
+
+    // Terminate project as admin
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.terminate_project(project_id);
+    stop_cheat_caller_address(admin_address);
+
+    // Try to create fund request on terminated project
+    cheat_caller_address(contract_address, project_owner, CheatSpan::Indefinite);
+    dispatcher.create_fund_request(project_id, milestone_id);
+    stop_cheat_caller_address(project_owner);
+}
+
+#[test]
+#[should_panic(expected:'Project is terminated')]
+fn test_attempt_to_create_multiple_milestones_after_termination() {
+ 
+    let (contract_address, admin_address, _, _, project_id, _) = setup_project_with_milestones();
+    let (_, _, _, _, project_id2, _) = setup_project_with_milestones();
+
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    let name = 'Dinah';
+    let org_address = contract_address_const::<'Organization 1'>();
+    let mission = 'Help the Poor';
+
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    let _org0_id = dispatcher.create_organization(name, org_address, mission);
+    dispatcher.create_milestone(org_address, project_id, 'Feed Dogs in Lekki', 2);
+    stop_cheat_caller_address(admin_address);
+
+
+     // Terminate project as admin
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.terminate_project(project_id);
+    stop_cheat_caller_address(admin_address);
+
+    cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
+    dispatcher.create_milestone(org_address, project_id2, 'Feed Dogs in Kubwa', 20);
+    stop_cheat_caller_address(admin_address);
 }
 

--- a/tests/test_budgetchain.cairo
+++ b/tests/test_budgetchain.cairo
@@ -193,7 +193,6 @@ fn test_create_milestone_successfully() {
     // let (contract_address, admin_address) = setup();
     let (contract_address, admin_address, _, _, project_id, _) = setup_project_with_milestones();
 
-
     let dispatcher = IBudgetDispatcher { contract_address };
 
     let name = 'John';
@@ -643,8 +642,7 @@ fn test_get_transaction_history_invalid_page_size_too_large() {
 #[should_panic(expected: 'Invalid page number')]
 fn test_get_transaction_history_page_beyond_range() {
     // Setup contract
-     let (contract_address, admin_address, _, _, project_id, _) =
-        setup_project_with_milestones();
+    let (contract_address, admin_address, _, _, project_id, _) = setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
     let recipient = contract_address_const::<'recipient'>();
     let project_id: u64 = project_id;
@@ -667,8 +665,7 @@ fn test_get_transaction_history_page_beyond_range() {
 #[test]
 fn test_get_transaction_history_single_transaction() {
     // Setup contract
-    let (contract_address, admin_address, _, _, project_id, _) =
-        setup_project_with_milestones();
+    let (contract_address, admin_address, _, _, project_id, _) = setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
     let recipient = contract_address_const::<'recipient'>();
     let project_id: u64 = project_id;
@@ -702,8 +699,7 @@ fn test_get_transaction_history_single_transaction() {
 #[test]
 fn test_get_transaction_history_max_page_size() {
     // Setup contract
-    let (contract_address, admin_address, _, _, project_id, _) =
-        setup_project_with_milestones();
+    let (contract_address, admin_address, _, _, project_id, _) = setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
     let recipient = contract_address_const::<'recipient'>();
     let project_id: u64 = project_id;
@@ -1603,7 +1599,7 @@ fn test_get_project_transactions_no_transactions() {
 #[test]
 #[should_panic]
 fn test_get_project_transactions_invalid_page() {
-     let (contract_address, _admin_address, _org_address, _project_owner, project_id, _) =
+    let (contract_address, _admin_address, _org_address, _project_owner, project_id, _) =
         setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
     let project_id: u64 = project_id;
@@ -1631,8 +1627,7 @@ fn test_get_project_transactions_invalid_page_size_too_large() {
 #[test]
 fn test_get_project_transactions_single_transaction() {
     // let (contract_address, _) = setup();
-    let (contract_address, _, _, _, project_id, _) =
-        setup_project_with_milestones();
+    let (contract_address, _, _, _, project_id, _) = setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
     let recipient = contract_address_const::<'recipient'>();
     let project_id: u64 = project_id;
@@ -1653,46 +1648,46 @@ fn test_get_project_transactions_multiple_projects_isolationv2() {
     // Setup project with milestones
     let (contract_address, _, org_address, project_owner, project_id, _) =
         setup_project_with_milestones();
-        
-        let dispatcher = IBudgetDispatcher { contract_address };
 
-        // Create another project to get another project_id with project status set to true 
-    
-        // Create a second project in the same contract
-        cheat_caller_address(contract_address, org_address, CheatSpan::Indefinite);
-        let project_id2 = dispatcher.allocate_project_budget(
+    let dispatcher = IBudgetDispatcher { contract_address };
+
+    // Create another project to get another project_id with project status set to true
+
+    // Create a second project in the same contract
+    cheat_caller_address(contract_address, org_address, CheatSpan::Indefinite);
+    let project_id2 = dispatcher
+        .allocate_project_budget(
             org_address,
             project_owner,
             2000, // different budget
             array!['Second Project Milestone'],
-            array![2000]
+            array![2000],
         );
-        stop_cheat_caller_address(org_address);
+    stop_cheat_caller_address(org_address);
 
     let recipient = contract_address_const::<'recipient'>();
     let project_id1 = project_id;
     let project_id2 = project_id2;
-   let category1: felt252 = project_id1.into();
+    let category1: felt252 = project_id1.into();
     let category2: felt252 = project_id2.into();
     dispatcher.create_transaction(project_id1, recipient, 1, category1, 'P1-T1').unwrap();
-   dispatcher.create_transaction(project_id2, recipient, 2, category2, 'P2-T1').unwrap();
-     dispatcher.create_transaction(project_id1, recipient, 3, category1, 'P1-T2').unwrap();
+    dispatcher.create_transaction(project_id2, recipient, 2, category2, 'P2-T1').unwrap();
+    dispatcher.create_transaction(project_id1, recipient, 3, category1, 'P1-T2').unwrap();
     let (txs1, total1) = dispatcher.get_project_transactions(project_id1, 1, 10).unwrap();
     let (txs2, total2) = dispatcher.get_project_transactions(project_id2, 1, 10).unwrap();
-     assert!(total1 == 2_u64, "Project 1 should have 2 transactions");
-     assert!(total2 == 1_u64, "Project 2 should have 1 transaction");
+    assert!(total1 == 2_u64, "Project 1 should have 2 transactions");
+    assert!(total2 == 1_u64, "Project 2 should have 1 transaction");
     assert!(txs1.len() == 2_u32, "Project 1 should return 2 transactions");
-     assert!(txs2.len() == 1_u32, "Project 2 should return 1 transaction");
+    assert!(txs2.len() == 1_u32, "Project 2 should return 1 transaction");
     assert(txs1.get(0).unwrap().description == 'P1-T1', 'Project 1, Tx 1 desc mismatch');
     assert(txs1.get(1).unwrap().description == 'P1-T2', 'Project 1, Tx 2 desc mismatch');
-     assert(txs2.get(0).unwrap().description == 'P2-T1', 'Project 2, Tx 1 desc mismatch');
+    assert(txs2.get(0).unwrap().description == 'P2-T1', 'Project 2, Tx 1 desc mismatch');
 }
 
 #[test]
 fn test_project_transaction_count_and_storage() {
     // Setup project
-    let (contract_address, _, _, _, project_id, _) =
-        setup_project_with_milestones();
+    let (contract_address, _, _, _, project_id, _) = setup_project_with_milestones();
     let dispatcher = IBudgetDispatcher { contract_address };
     let recipient = contract_address_const::<'recipient'>();
     let project_id: u64 = project_id;
@@ -2124,7 +2119,7 @@ fn test_create_fund_request_on_terminated_project() {
         .create_milestone(org_address, project_id, 'Full Budget Milestone', total_budget);
     stop_cheat_caller_address(admin_address);
 
-     // Mark milestone as complete
+    // Mark milestone as complete
     cheat_caller_address(contract_address, project_owner, CheatSpan::Indefinite);
     dispatcher.set_milestone_complete(project_id, milestone_id);
     stop_cheat_caller_address(project_owner);
@@ -2145,9 +2140,8 @@ fn test_create_fund_request_on_terminated_project() {
 }
 
 #[test]
-#[should_panic(expected:'Project is terminated')]
+#[should_panic(expected: 'Project is terminated')]
 fn test_attempt_to_create_multiple_milestones_after_termination() {
- 
     let (contract_address, admin_address, _, _, project_id, _) = setup_project_with_milestones();
     let (_, _, _, _, project_id2, _) = setup_project_with_milestones();
 
@@ -2162,8 +2156,7 @@ fn test_attempt_to_create_multiple_milestones_after_termination() {
     dispatcher.create_milestone(org_address, project_id, 'Feed Dogs in Lekki', 2);
     stop_cheat_caller_address(admin_address);
 
-
-     // Terminate project as admin
+    // Terminate project as admin
     cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
     dispatcher.terminate_project(project_id);
     stop_cheat_caller_address(admin_address);


### PR DESCRIPTION
## Description
### Add Project Termination Feature 

This pull request introduces functionality to manage project termination within the `Budget` module, including the ability to mark projects as terminated and enforce project status checks across various operations. It also updates the test suite to accommodate these changes. 

Below are the key changes grouped by theme:

### Core Functionality Enhancements
* Added `project_status` mapping to track the active or terminated state of projects (`src/budgetchain/Budget.cairo`).
* Introduced the `terminate_project` function to allow admins to terminate projects and emit a `ProjectTerminated` event (`src/budgetchain/Budget.cairo`).
* Added `_assert_project_active` helper function to ensure operations are only performed on active projects (`src/budgetchain/Budget.cairo`).

### 🔴 Project Termination System
- **New Functions:**
  - `terminate_project()` - Allows admin to terminate projects
  - `assert_status()` - Check project active/terminated status
  - `is_project_terminated()` - Query project termination state
  - `_assert_project_active()` - Internal validation for active projects

- **Project Status Tracking:**
  - Added `project_status` storage mapping for tracking project states
  - Projects default to active (`true`) when created via `allocate_project_budget`
  
  ## 🔒 **Security Enhancements**

### Project Termination Safeguards
- **Function Protection:** Added termination checks to:
  - `create_fund_request()` - Cannot request funds for terminated projects
  - `create_milestone()` - Cannot create milestones for terminated projects (optional)
  - `release_funds()` - Cannot release funds for terminated projects

- **Status Integrity:**
  - Once terminated, projects cannot be reactivated
  - Prevents accidental fund releases on closed projects
  - Maintains audit trail of project states

### Admin Controls
- Only admin can terminate projects
- Proper authorization checks on all new functions

###  **New Error Messages**
```cairo
pub const ERROR_PROJECT_TERMINATED: felt252 = 'Project is terminated';
pub const ERROR_PROJECT_ALREADY_TERMINATED: felt252 = 'Project already terminated';
pub const ERROR_CONTRACT_PAUSED: felt252 = 'Contract is paused';
pub const ERROR_ALREADY_PAUSED: felt252 = 'Contract already paused';
```
### Interface Updates
* Updated `IBudget` interface to include `terminate_project` and `assert_status` functions for project management (`src/interfaces/IBudget.cairo`).

##  **Technical Details**
### Storage Changes:
**Function Modifications:**
- Updated allocate_project_budget() to set project status to true
- Added pause checks to all state-changing functions
- Enhanced project validation in fund-related operations


### Test Suite Updates
* Modified tests to use the `setup_project_with_milestones` helper, ensuring projects are initialized with proper status checks (`tests/test_budgetchain.cairo`). [[1]](diffhunk://#diff-a3e6b7dbba9a4cd9c6f889bd7bd7ca8f792cba8121a0841b11f4da6fef5eb0f7L193-R195) [[2]](diffhunk://#diff-a3e6b7dbba9a4cd9c6f889bd7bd7ca8f792cba8121a0841b11f4da6fef5eb0f7L219-R224) [[3]](diffhunk://#diff-a3e6b7dbba9a4cd9c6f889bd7bd7ca8f792cba8121a0841b11f4da6fef5eb0f7L1624-R1638)
* Added test cases for project isolation, ensuring transactions are correctly associated with their respective projects (`tests/test_budgetchain.cairo`).

### Testing Status
- All existing tests pass ✅
- New functionality fully tested ✅
- Edge cases covered ✅
- Error conditions validated ✅

Closes #51 

![image](https://github.com/user-attachments/assets/11499347-a061-4c9e-a9ee-05dd648948dc)
